### PR TITLE
issue #11 - projections worker initial work and tests

### DIFF
--- a/src/Bridge/Symfony/Resources/config/projector-console.yaml
+++ b/src/Bridge/Symfony/Resources/config/projector-console.yaml
@@ -2,10 +2,14 @@ services:
 
     Goat\Domain\Command\ProjectorListCommand:
         public: false
-        arguments: ["@goat.domain.projector_registry"]
+        arguments:
+            - "@goat.domain.projector_registry"
+            - "@goat.domain.projector_state_store"
         tags: ["console.command"]
 
     Goat\Domain\Command\ProjectorPlayCommand:
         public: false
-        arguments: ["@goat.domain.projector_registry", "@goat.domain.event_store"]
+        arguments:
+            - "@goat.domain.projector_registry"
+            - "@goat.domain.projector_worker"
         tags: ["console.command"]

--- a/src/Bridge/Symfony/Resources/config/projector.yaml
+++ b/src/Bridge/Symfony/Resources/config/projector.yaml
@@ -1,5 +1,43 @@
 services:
 
+    # Allows to maintain a different SQL connection for the projector state
+    # store, allowing it to go out of business transactions scope.
+    goat.runner.projector_state:
+        alias: "goat.runner.default"
+
     goat.domain.projector_registry:
         public: false
         class: Goat\Domain\Projector\ProjectorRegistry
+
+    goat.domain.projector_state_store.goat:
+        public: false
+        class: Goat\Domain\Projector\State\GoatStateStore
+        arguments:
+            - "@goat.runner.projector_state"
+
+    goat.domain.projector_state_store:
+        alias: goat.domain.projector_state_store.goat
+
+    Goat\Domain\Projector\State\StateStore:
+        alias: goat.domain.projector_state_store
+
+    goat.domain.projector_worker:
+        public: false
+        class: Goat\Domain\Projector\Worker\DefaultWorker
+        arguments:
+            - "@goat.domain.projector_registry"
+            - "@goat.domain.event_store"
+            - "@goat.domain.projector_state_store"
+
+    Goat\Domain\Projector\Worker\Worker:
+        alias: goat.domain.projector_worker
+
+    goat.domain.projector_player:
+        public: false
+        class: Goat\Domain\Projector\Runtime\DefaultRuntimePlayer
+        arguments:
+            - "@goat.domain.projector_registry"
+            - "@goat.domain.projector_state_store"
+
+    Goat\Domain\Projector\Runtime\RuntimePlayer:
+        alias: goat.domain.projector_player

--- a/src/Domain/Command/ProjectorPlayCommand.php
+++ b/src/Domain/Command/ProjectorPlayCommand.php
@@ -140,5 +140,7 @@ final class ProjectorPlayCommand extends Command
                 $progressBar->setProgress($event->getCurrentPosition());
             }
         );
+
+        return $progressBar;
     }
 }

--- a/src/Domain/Command/ProjectorPlayCommand.php
+++ b/src/Domain/Command/ProjectorPlayCommand.php
@@ -55,7 +55,7 @@ final class ProjectorPlayCommand extends Command
             throw new \InvalidArgumentException("You can not use both 'reset' and 'date' options, you have to choose one.");
         }
 
-        $projector = $this->projectorRegistry->findByIdentifierOrClassName($input->getArgument('projector'));
+        $projector = $this->projectorRegistry->find($input->getArgument('projector'));
 
         if ($input->getOption('reset')) {
             $this->handleReset($projector);

--- a/src/Domain/Event/MessageEnvelope.php
+++ b/src/Domain/Event/MessageEnvelope.php
@@ -8,9 +8,6 @@ use Goat\Domain\EventStore\Property;
 use Goat\Domain\EventStore\WithPropertiesTrait;
 use Ramsey\Uuid\Uuid;
 
-/**
- * Default event implementation, just extend this class.
- */
 final class MessageEnvelope
 {
     use WithPropertiesTrait;

--- a/src/Domain/EventStore/Testing/DummyArrayEventStream.php
+++ b/src/Domain/EventStore/Testing/DummyArrayEventStream.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\EventStore\Testing;
+
+use Goat\Domain\EventStore\Event;
+use Goat\Domain\EventStore\EventStream;
+
+/**
+ * @var \Goat\Domain\Event\Event[]
+ */
+class DummyArrayEventStream implements EventStream, \Iterator
+{
+    /** @var Event[] */
+    private array $events;
+    private int $index = -1;
+    private ?Event $current = null;
+
+    /** @var Event */
+    public function __construct(array $events)
+    {
+        $this->events = \array_values($events);
+
+        $this->next();
+    }
+
+    /**
+     * Fetch next in stream.
+     *
+     * Warning: iterating over this instance will advance in stream.
+     */
+    public function fetch(): ?Event
+    {
+        $this->next();
+
+        return $this->current;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return \count($this->events);
+    }
+
+    /**
+     * {@inheritdoc}
+     */ 
+    public function next()
+    {
+        $this->current = $this->events[++$this->index] ?? null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid()
+    {
+        return null !== $this->current;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        return $this->current;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        $this->index = -1;
+        $this->current = null;
+
+        $this->next();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key()
+    {
+        return 0 <= $this->index ? $this->index : null;
+    }
+}

--- a/src/Domain/Projector/Projector.php
+++ b/src/Domain/Projector/Projector.php
@@ -9,6 +9,10 @@ use Goat\Domain\EventStore\Event;
 /**
  * Projectors will be process after an event has been consume.
  * It's mainly used to statistics purpose.
+ *
+ * Projector will consume events, sometime, events can be sent more than once
+ * so implementation must be able to detect that, ensuring event consumption
+ * to be reentrant.
  */
 interface Projector
 {

--- a/src/Domain/Projector/Projector.php
+++ b/src/Domain/Projector/Projector.php
@@ -7,7 +7,7 @@ namespace Goat\Domain\Projector;
 use Goat\Domain\EventStore\Event;
 
 /**
- * Projectors will be process after an event has been consume.
+ * Projectors will be process after an event has been consumed.
  * It's mainly used to statistics purpose.
  *
  * Projector will consume events, sometime, events can be sent more than once

--- a/src/Domain/Projector/Projector/BrokenProjector.php
+++ b/src/Domain/Projector/Projector/BrokenProjector.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\Projector;
+
+use Goat\Domain\EventStore\Event;
+use Goat\Domain\Projector\Projector;
+
+/**
+ * Null object pattern implementation.
+ */
+final class BrokenProjector implements Projector
+{
+    private string $id;
+    private int $onEventCount = 0;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onEvent(Event $event): void
+    {
+        ++$this->onEventCount;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastProcessedEventDate(): ?\DateTimeInterface
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHandledEvents(): ?array
+    {
+        return null;
+    }
+
+    public function getOnEventCallCount(): int
+    {
+        return $this->onEventCount;
+    }
+}

--- a/src/Domain/Projector/Projector/CallbackProjector.php
+++ b/src/Domain/Projector/Projector/CallbackProjector.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\Projector;
+
+use Goat\Domain\EventStore\Event;
+use Goat\Domain\Projector\Projector;
+
+/**
+ * Write a projector that uses a callback.
+ */
+class CallbackProjector implements Projector
+{
+    private string $id;
+    private int $onEventCount = 0;
+    /** @var callable */
+    private $callback;
+
+    public function __construct(string $id, callable $callback)
+    {
+        $this->id = $id;
+        $this->callback = $callback;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onEvent(Event $event): void
+    {
+        ++$this->onEventCount;
+
+        ($this->callback)($event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastProcessedEventDate(): ?\DateTimeInterface
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHandledEvents(): ?array
+    {
+        return null;
+    }
+
+    public function getOnEventCallCount(): int
+    {
+        return $this->onEventCount;
+    }
+}

--- a/src/Domain/Projector/ProjectorDoesNotExistError.php
+++ b/src/Domain/Projector/ProjectorDoesNotExistError.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector;
+
+class ProjectorDoesNotExistError extends \InvalidArgumentException implements ProjectorError
+{
+    public function __construct(string $id)
+    {
+        parent::__construct(\sprintf("Projector with class or identifier '%s' does not exist", $id));
+    }
+}

--- a/src/Domain/Projector/ProjectorError.php
+++ b/src/Domain/Projector/ProjectorError.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector;
+
+interface ProjectorError extends \Throwable
+{
+}

--- a/src/Domain/Projector/ProjectorNotReplyableError.php
+++ b/src/Domain/Projector/ProjectorNotReplyableError.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector;
+
+class ProjectorNotReplyableError extends \InvalidArgumentException implements ProjectorError
+{
+    public function __construct(string $id)
+    {
+        parent::__construct(\sprintf("Projector '%s' cannot be reset", $id));
+    }
+}

--- a/src/Domain/Projector/ProjectorRegistry.php
+++ b/src/Domain/Projector/ProjectorRegistry.php
@@ -34,26 +34,23 @@ class ProjectorRegistry
     /**
      * Find a projector by identifier.
      */
-    protected function findByIdentifier(string $identifier, bool $throwExceptionOnMissing = true): ?Projector
+    protected function findByIdentifier(string $id, bool $throwExceptionOnMissing = true): ?Projector
     {
         $this->isInitializedOrDie();
 
         if ($this->projectors) {
             foreach ($this->projectors as $projector) {
-                if ($identifier === $projector->getIdentifier()) {
+                if ($id === $projector->getIdentifier()) {
                     return $projector;
                 }
             }
         }
 
         if ($throwExceptionOnMissing) {
-            throw new \InvalidArgumentException(\sprintf(
-                "No projector can't be found for identifier '%s'",
-                $identifier
-            ));
-        } else {
-            return null;
+            throw new ProjectorDoesNotExistError($id);
         }
+
+        return null;
     }
 
     /**
@@ -72,19 +69,16 @@ class ProjectorRegistry
         }
 
         if ($throwExceptionOnMissing) {
-            throw new \InvalidArgumentException(\sprintf(
-                "No projector can't be found for className '%s'",
-                $className
-            ));
-        } else {
-            return null;
+            throw new ProjectorDoesNotExistError($className);
         }
+
+        return null;
     }
 
     /**
      * Find a projector by identifier or by class name.
      */
-    public function findByIdentifierOrClassName(string $identifierOrClassName, bool $throwExceptionOnMissing = true): ?Projector
+    public function find(string $identifierOrClassName, bool $throwExceptionOnMissing = true): ?Projector
     {
         if ( $projector = $this->findByIdentifier($identifierOrClassName, false)) {
             return $projector;
@@ -93,13 +87,10 @@ class ProjectorRegistry
         }
 
         if ($throwExceptionOnMissing) {
-            throw new \InvalidArgumentException(\sprintf(
-                "No projector can't be found for identifier or className '%s'",
-                $identifierOrClassName
-            ));
-        } else {
-            return null;
+            throw new ProjectorDoesNotExistError($identifierOrClassName);
         }
+
+        return null;
     }
 
     public function setProjectors(iterable $projectors): void

--- a/src/Domain/Projector/Runtime/DefaultRuntimePlayer.php
+++ b/src/Domain/Projector/Runtime/DefaultRuntimePlayer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\Runtime;
+
+use Goat\Domain\EventStore\Event;
+use Goat\Domain\Projector\Projector;
+use Goat\Domain\Projector\ProjectorRegistry;
+use Goat\Domain\Projector\State\StateStore;
+
+/**
+ * @todo Instrument using psr/log.
+ */
+final class DefaultRuntimePlayer implements RuntimePlayer
+{
+    private ProjectorRegistry $projectorRegistry;
+    private StateStore $stateStore;
+
+    public function __construct(ProjectorRegistry $projectorRegistry, StateStore $stateStore)
+    {
+        $this->projectorRegistry = $projectorRegistry;
+        $this->stateStore = $stateStore;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dispatch(Event $event): void
+    {
+        $projectors = $this->projectorRegistry->getAll();
+
+        foreach ($projectors as $projector) {
+            \assert($projector instanceof Projector);
+
+            $id = $projector->getIdentifier();
+
+            // @todo Optimize this by loading everything at once.
+            $state = $this->stateStore->latest($id);
+
+            try {
+                if (!$state || $state->getLatestEventPosition() < $event->getPosition()) {
+                    $projector->onEvent($event);
+
+                    // @todo Optimize this by updating all at once.
+                    $this->stateStore->update($id, $event, true);
+                }
+            } catch (\Throwable $e) {
+                $state = $this->stateStore->exception($id, $event, $e, true);
+            }
+        }
+    }
+}

--- a/src/Domain/Projector/Runtime/RuntimePlayer.php
+++ b/src/Domain/Projector/Runtime/RuntimePlayer.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\Runtime;
+
+use Goat\Domain\EventStore\Event;
+
+interface RuntimePlayer
+{
+    /**
+     * Play a single event over all projectors.
+     */
+    public function dispatch(Event $event): void;
+}

--- a/src/Domain/Projector/State/ArrayStateStore.php
+++ b/src/Domain/Projector/State/ArrayStateStore.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\State;
+
+use Goat\Domain\EventStore\Event;
+
+/**
+ * You may decorate this implementation to use another backend such as file
+ * storage or such.
+ *
+ * Otherwise, it's mostly used for tests.
+ */
+final class ArrayStateStore implements StateStore
+{
+    /** @var array<string, State> */
+    private array $data = [];
+
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $state) {
+            $this->set($state);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lock(string $id): State
+    {
+        $existing = $this->latest($id);
+
+        if ($existing) {
+            if ($existing->isLocked()) {
+                throw new ProjectorLockedError($id);
+            }
+
+            return $this->set(
+                $existing->clone(
+                    null,
+                    null,
+                    false
+                )
+            );
+        }
+
+        return $this->set(State::empty($id, true));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unlock(string $id): State
+    {
+        $existing = $this->latest($id);
+
+        if ($existing) {
+            if ($existing->isLocked()) {
+                return $this->set(
+                    $existing->clone(
+                        null,
+                        null,
+                        false
+                    )
+                );
+            }
+
+            return $existing;
+        }
+
+        return $this->set(State::empty($id, false));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update(string $id, Event $event, bool $unlock = true): State
+    {
+        $existing = $this->latest($id);
+
+        if ($existing) {
+            return $this->set(
+                $existing->clone(
+                    $event->validAt(),
+                    $event->getPosition(),
+                    $unlock ? false : $existing->isLocked(),
+                    false
+                )
+            );
+        }
+
+        return $this->set(
+            $this->create(
+                $id,
+                $event->validAt(),
+                $event->getPosition(),
+                false,
+                false
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function error(string $id, Event $event, string $message, int $errorCode = 0, bool $unlock = true): State
+    {
+        $existing = $this->latest($id);
+
+        if ($existing) {
+            return $this->set(
+                $existing->clone(
+                    $event->validAt(),
+                    $event->getPosition(),
+                    false,
+                    true,
+                    $message,
+                    $errorCode
+                )
+            );
+        }
+
+        return $this->set(
+            $this->create(
+                $id,
+                $event->validAt(),
+                $event->getPosition(),
+                false,
+                true,
+                $errorCode,
+                $message
+                // @todo Trace?
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function exception(string $id, Event $event, \Throwable $exception, bool $unlock = true): State
+    {
+        $existing = $this->latest($id);
+
+        if ($existing) {
+            return $this->set(
+                $existing->clone(
+                    $event->validAt(),
+                    $event->getPosition(),
+                    false,
+                    true,
+                    $exception->getCode(),
+                    $exception->getMessage()
+                    // @todo Trace?
+                )
+            );
+        }
+
+        return $this->set(
+            $this->create(
+                $id,
+                $event->validAt(),
+                $event->getPosition(),
+                false,
+                true,
+                $exception->getCode(),
+                $exception->getMessage()
+                // @todo Trace?
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function latest(string $id): ?State
+    {
+        return $this->data[$id] ?? null;
+    }
+
+    /**
+     * Set and return item.
+     */
+    private function set(State $state): State
+    {
+        return $this->data[$state->getProjectorId()] = $state;
+    }
+
+    /**
+     * Create new item with data.
+     */
+    private function create(
+        string $id,
+        \DateTimeInterface $date,
+        int $position = 0,
+        bool $isLocked = false,
+        bool $isError = false,
+        int $errorCode = 0,
+        ?string $errorMessage = null,
+        ?string $errorTrace = null
+    ): State {
+        return new State(
+            $id,
+            new \DateTimeImmutable(),
+            new \DateTimeImmutable(),
+            $date,
+            $position,
+            $isLocked,
+            $isError,
+            $errorCode,
+            $errorMessage,
+            $errorTrace
+        );
+    }
+}

--- a/src/Domain/Projector/State/ArrayStateStore.php
+++ b/src/Domain/Projector/State/ArrayStateStore.php
@@ -40,7 +40,7 @@ final class ArrayStateStore implements StateStore
                 $existing->clone(
                     null,
                     null,
-                    false
+                    true
                 )
             );
         }
@@ -150,8 +150,8 @@ final class ArrayStateStore implements StateStore
                     false,
                     true,
                     $exception->getCode(),
-                    $exception->getMessage()
-                    // @todo Trace?
+                    $exception->getMessage(),
+                    self::normalizeExceptionTrace($exception)
                 )
             );
         }
@@ -164,8 +164,8 @@ final class ArrayStateStore implements StateStore
                 false,
                 true,
                 $exception->getCode(),
-                $exception->getMessage()
-                // @todo Trace?
+                $exception->getMessage(),
+                self::normalizeExceptionTrace($exception)
             )
         );
     }
@@ -176,6 +176,23 @@ final class ArrayStateStore implements StateStore
     public function latest(string $id): ?State
     {
         return $this->data[$id] ?? null;
+    }
+
+    /**
+     * Normalize exception trace.
+     */
+    public static function normalizeExceptionTrace(\Throwable $exception): string
+    {
+        $output = '';
+        do {
+            if ($output) {
+                $output .= "\n";
+            }
+            $output .= \sprintf("%s: %s\n", \get_class($exception), $exception->getMessage());
+            $output .= $exception->getTraceAsString();
+        } while ($exception = $exception->getPrevious());
+
+        return $output;
     }
 
     /**

--- a/src/Domain/Projector/State/GoatStateStore.php
+++ b/src/Domain/Projector/State/GoatStateStore.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Goat\Domain\Projector\State;
 
 use Goat\Domain\EventStore\Event;
+use Goat\Query\ExpressionRaw;
 use Goat\Query\ExpressionRelation;
 use Goat\Query\Query;
 use Goat\Query\QueryBuilder;
-use Goat\Runner\Runner;
-use Goat\Query\ExpressionRaw;
 use Goat\Query\SelectQuery;
+use Goat\Runner\Runner;
 
 /**
  * goat-query/pgsql implementation.

--- a/src/Domain/Projector/State/GoatStateStore.php
+++ b/src/Domain/Projector/State/GoatStateStore.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\State;
+
+use Goat\Domain\EventStore\Event;
+use Goat\Query\ExpressionRelation;
+use Goat\Query\Query;
+use Goat\Query\QueryBuilder;
+use Goat\Runner\Runner;
+use Goat\Query\ExpressionRaw;
+use Goat\Query\SelectQuery;
+
+/**
+ * goat-query/pgsql implementation.
+ */
+final class GoatStateStore implements StateStore
+{
+    private Runner $runner;
+    private string $schema;
+
+    public function __construct(Runner $runner, string $schema = 'public')
+    {
+        $this->runner = $runner;
+        $this->schema = $schema;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lock(string $id): State
+    {
+        return $this->runner->runTransaction(function (QueryBuilder $builder) use ($id): State {
+            $table = $this->table();
+
+            $isLocked = $builder
+                ->select($table)
+                ->column('is_locked')
+                ->condition('id', $id)
+                ->forUpdate()
+                ->execute()
+                ->fetchField()
+            ;
+
+            if ($isLocked) {
+                throw new ProjectorLockedError($id);
+            }
+
+            $query = $builder
+                ->merge($table)
+                ->onConflictUpdate()
+                ->setKey(['id'])
+                ->values([
+                    'id' => $id,
+                    'updated_at' => ExpressionRaw::create('current_timestamp'),
+                    'is_locked' => true,
+                    // 'is_error' bool NOT NULL DEFAULT false,
+                    // 'error_code' bigint NOT NULL DEFAULT 0,
+                    // 'error_message' text DEFAULT null,
+                    // 'error_trace' 'ext DEFAULT null,
+                ])
+            ;
+
+            return $this->columns($query)->execute()->fetch();
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unlock(string $id): State
+    {
+        $query = $this
+            ->runner
+            ->getQueryBuilder()
+            ->merge($this->table())
+            ->onConflictUpdate()
+            ->setKey(['id'])
+            ->values([
+                'id' => $id,
+                'updated_at' => ExpressionRaw::create('current_timestamp'),
+                'is_locked' => false,
+                'is_error' => false,
+                'error_code' => 0,
+                'error_message' => null,
+                'error_trace' => null,
+            ])
+        ;
+
+        return $this->columns($query)->execute()->fetch();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update(string $id, Event $event, bool $unlock = true): State
+    {
+        $values = [
+            'id' => $id,
+            'updated_at' => ExpressionRaw::create('current_timestamp'),
+            'last_position' => $event->getPosition(),
+            'last_valid_at' => $event->validAt(),
+            'is_error' => false,
+            'error_code' => 0,
+            'error_message' => null,
+            'error_trace' => null,
+        ];
+
+        if ($unlock) {
+            $values['is_locked'] = false;
+        }
+
+        $query = $this
+            ->runner
+            ->getQueryBuilder()
+            ->merge($this->table())
+            ->onConflictUpdate()
+            ->setKey(['id'])
+            ->values($values)
+        ;
+
+        return $this->columns($query)->execute()->fetch();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function error(string $id, Event $event, string $message, int $errorCode = 0, bool $unlock = true): State
+    {
+        $values = [
+            'id' => $id,
+            'updated_at' => ExpressionRaw::create('current_timestamp'),
+            'last_position' => $event->getPosition(),
+            'last_valid_at' => $event->validAt(),
+            'is_error' => true,
+            'error_code' => $errorCode,
+            'error_message' => $message,
+            'error_trace' => null,
+        ];
+
+        if ($unlock) {
+            $values['is_locked'] = false;
+        }
+
+        $query = $this
+            ->runner
+            ->getQueryBuilder()
+            ->merge($this->table())
+            ->onConflictUpdate()
+            ->setKey(['id'])
+            ->values($values)
+        ;
+
+        return $this->columns($query)->execute()->fetch();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function exception(string $id, Event $event, \Throwable $exception, bool $unlock = true): State
+    {
+        $values = [
+            'id' => $id,
+            'updated_at' => ExpressionRaw::create('current_timestamp'),
+            'last_position' => $event->getPosition(),
+            'last_valid_at' => $event->validAt(),
+            'is_error' => true,
+            'error_code' => $exception->getCode(),
+            'error_message' => $exception->getMessage(),
+            'error_trace' => ArrayStateStore::normalizeExceptionTrace($exception),
+        ];
+
+        if ($unlock) {
+            $values['is_locked'] = false;
+        }
+
+        $query = $this
+            ->runner
+            ->getQueryBuilder()
+            ->merge($this->table())
+            ->onConflictUpdate()
+            ->setKey(['id'])
+            ->values($values)
+        ;
+
+        return $this->columns($query)->execute()->fetch();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function latest(string $id): ?State
+    {
+        return $this
+            ->columns(
+                $this
+                    ->runner
+                    ->getQueryBuilder()
+                    ->select($this->table())
+                    ->condition('id', $id)
+            )
+            ->execute()
+            ->fetch()
+        ;
+    }
+
+    private function columns(Query $query): Query
+    {
+        $aliases = [
+            'id' => 'id',
+            'created_at' => 'createdAt',
+            'updated_at' => 'updatedAt',
+            'last_position' => 'position',
+            'last_valid_at' => 'date',
+            'is_locked' => 'isLocked',
+            'is_error' => 'isError',
+            'error_code' => 'errorCode',
+            'error_message' => 'errorMessage',
+            'error_trace' => 'errorTrace',
+        ];
+
+        if ($query instanceof SelectQuery) {
+            foreach ($aliases as $column => $alias) {
+                $query->column($column, $alias);
+            }
+        } else {
+            foreach ($aliases as $column => $alias) {
+                $query->returning($column, $alias);
+            }
+        }
+
+        return $query->setOption('class', State::class);
+    }
+
+    private function table(): ExpressionRelation
+    {
+        return ExpressionRelation::create('projector_state', $this->schema);
+    }
+}

--- a/src/Domain/Projector/State/ProjectorLockedError.php
+++ b/src/Domain/Projector/State/ProjectorLockedError.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\State;
+
+use Goat\Domain\Projector\ProjectorError;
+
+class ProjectorLockedError extends \InvalidArgumentException implements ProjectorError
+{
+    public function __construct(string $id)
+    {
+        parent::__construct(\sprintf("Projector '%s' is already locked.", $id));
+    }
+}

--- a/src/Domain/Projector/State/State.php
+++ b/src/Domain/Projector/State/State.php
@@ -141,6 +141,7 @@ final class State
                 $ret->errorMessage = $errorMessage;
                 $ret->errorTrace = $errorTrace;
             } else {
+                $ret->errorCode = $errorCode ?? 0;
                 $ret->errorMessage = null;
                 $ret->errorTrace = null;
             }

--- a/src/Domain/Projector/State/State.php
+++ b/src/Domain/Projector/State/State.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\State;
+
+final class State
+{
+    private string $id;
+    private \DateTimeInterface $createdAt;
+    private \DateTimeInterface $updatedAt;
+    private \DateTimeInterface $date;
+    private int $position = 0;
+    private bool $isLocked = false;
+    private bool $isError = false;
+    private int $errorCode = 0;
+    private ?string $errorMessage = null;
+    private ?string $errorTrace = null;
+
+    public function __construct(
+        string $id,
+        \DateTimeInterface $createdAt,
+        \DateTimeInterface $updatedAt,
+        \DateTimeInterface $date,
+        int $position = 0,
+        bool $isLocked = false,
+        bool $isError = false,
+        int $errorCode = 0,
+        ?string $errorMessage = null,
+        ?string $errorTrace = null
+    ) {
+        $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
+        $this->date = $date;
+        $this->position = $position;
+        $this->isLocked = $isLocked;
+        $this->isError = $isError;
+        $this->errorCode = $errorCode;
+        $this->errorMessage = $errorMessage;
+        $this->errorTrace = $errorTrace;
+    }
+
+    public static function empty(string $id, bool $isLocked = false): self
+    {
+        return new self(
+            $id,
+            $now = new \DateTimeImmutable(),
+            $now,
+            new \DateTimeImmutable("@0"),
+            0,
+            $isLocked
+        );
+    }
+
+    public function getProjectorId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCreationDate(): \DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function getUpdateDate(): \DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function getLatestEventDate(): \DateTimeInterface
+    {
+        return $this->date;
+    }
+
+    public function getLatestEventPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function isLocked(): bool
+    {
+        return $this->isLocked;
+    }
+
+    public function isError(): bool
+    {
+        return $this->isError;
+    }
+
+    public function getErrorCode(): int
+    {
+        return $this->errorCode;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    public function getErrorTrace(): ?string
+    {
+        return $this->errorTrace;
+    }
+
+    /**
+     * For unit testing.
+     *
+     * @internal
+     * @see ArrayStateStore
+     */
+    public function clone(
+        \DateTimeInterface $date = null,
+        ?int $position = null,
+        ?bool $isLocked = null,
+        ?bool $isError = null,
+        ?int $errorCode = null,
+        ?string $errorMessage = null,
+        ?string $errorTrace = null
+    ): self {
+        $ret = clone $this;
+        $ret->createdAt = clone $ret->createdAt;
+        $ret->updatedAt = new \DateTimeImmutable();
+
+        if (null !== $date) {
+            $ret->date = $date;
+        }
+        if (null !== $position) {
+            $ret->position = $position;
+        }
+        if (null !== $isLocked) {
+            $ret->isLocked = $isLocked;
+        }
+
+        if (null !== $errorCode) {
+            $ret->errorCode = $errorCode;
+        }
+        if (null !== $isError) {
+            $ret->isError = $isError;
+            if ($isError) {
+                $ret->errorMessage = $errorMessage;
+                $ret->errorTrace = $errorTrace;
+            } else {
+                $ret->errorMessage = null;
+                $ret->errorTrace = null;
+            }
+        }
+
+        return $ret;
+    }
+}

--- a/src/Domain/Projector/State/StateStore.php
+++ b/src/Domain/Projector/State/StateStore.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\State;
+
+use Goat\Domain\EventStore\Event;
+
+interface StateStore
+{
+    /**
+     * Lock single projector (which mean it cannot be concurently processed).
+     *
+     * Raise an exception if projector was already locked.
+     *
+     * @throws ProjectorLockedError
+     */
+    public function lock(string $id): State;
+
+    /**
+     * Unlock single projector.
+     */
+    public function unlock(string $id): State;
+
+    /**
+     * Update projector state, set its last dispatched event.
+     *
+     * @throws ProjectorLockedError
+     */
+    public function update(string $id, Event $event, bool $unlock = true): State;
+
+    /**
+     * Update projector state, set error.
+     *
+     * @throws ProjectorLockedError
+     */
+    public function error(string $id, Event $event, string $message, int $errorCode = 0, bool $unlock = true): State;
+
+    /**
+     * Update projector state, set error using PHP exception.
+     *
+     * @throws ProjectorLockedError
+     */
+    public function exception(string $id, Event $event, \Throwable $exception, bool $unlock = true): State;
+
+    /**
+     * Get latest event for projector.
+     */
+    public function latest(string $id): ?State;
+}

--- a/src/Domain/Projector/State/install.pg.sql
+++ b/src/Domain/Projector/State/install.pg.sql
@@ -1,0 +1,20 @@
+
+-- ----------------------------------------------------------------------------
+--
+-- Event store tables schema.
+--
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE "projector_state" (
+    "id" varchar(500) NOT NULL,
+    "created_at" timestamp NOT NULL DEFAULT now(),
+    "updated_at" timestamp NOT NULL DEFAULT now(),
+    "position" bigint NOT NULL DEFAULT 0,
+    "is_locked" bool NOT NULL DEFAULT false,
+    "is_error" bool NOT NULL DEFAULT false,
+    "error_code" bigint NOT NULL DEFAULT 0,
+    "error_message" text DEFAULT null,
+    "error_trace" text DEFAULT null,
+    PRIMARY KEY("id")
+);
+

--- a/src/Domain/Projector/Worker/DefaultWorker.php
+++ b/src/Domain/Projector/Worker/DefaultWorker.php
@@ -219,7 +219,7 @@ final class DefaultWorker implements Worker
      *
      * @return array<string, ProjectorState>
      */
-    private function mapProjectors(iterable $projectors, bool $continueOnError)
+    private function mapProjectors(iterable $projectors, bool $continueOnError): array
     {
         $ret = [];
 

--- a/src/Domain/Projector/Worker/DefaultWorker.php
+++ b/src/Domain/Projector/Worker/DefaultWorker.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\Worker;
+
+use Goat\Domain\EventStore\Event;
+use Goat\Domain\EventStore\EventStore;
+use Goat\Domain\Projector\Projector;
+use Goat\Domain\Projector\ProjectorNotReplyableError;
+use Goat\Domain\Projector\ProjectorRegistry;
+use Goat\Domain\Projector\ReplayableProjector;
+use Goat\Domain\Projector\State\ProjectorLockedError;
+use Goat\Domain\Projector\State\State;
+use Goat\Domain\Projector\State\StateStore;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Default (and propably only) implementation.
+ *
+ * Interface exists for the need of decorating the worker.
+ */
+final class DefaultWorker implements Worker
+{
+    private ProjectorRegistry $projectorRegistry;
+    private EventStore $eventStore;
+    private StateStore $stateStore;
+    private ?EventDispatcherInterface $eventDispatcher = null;
+
+    public function __construct(
+        ProjectorRegistry $projectorRegistry,
+        EventStore $eventStore,
+        StateStore $stateStore
+    ) {
+        $this->projectorRegistry = $projectorRegistry;
+        $this->eventStore = $eventStore;
+        $this->stateStore = $stateStore;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->eventDispatcher ?? ($this->eventDispatcher = new EventDispatcher());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function play(string $id, bool $reset = false, bool $continueOnError = false): void
+    {
+        $this->doPlay([$this->getProjector($id)], null, $continueOnError);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function playFrom(string $id, \DateTimeInterface $from, bool $continueOnError = false): void
+    {
+        $this->doPlay([$this->getProjector($id)], $from, $continueOnError);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function playAll(bool $continueOnError = false): void
+    {
+        $this->doPlay($this->getAllProjectors(), null, $continueOnError);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function playAllFrom(\DateTimeInterface $from, bool $continueOnError = false): void
+    {
+        $this->doPlay($this->getAllProjectors(), $from, $continueOnError);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset(string $id): void
+    {
+        $projector = $this->projectorRegistry->find($id);
+
+        if ($projector instanceof ReplayableProjector) {
+            $projector->reset();
+        } else {
+            throw new ProjectorNotReplyableError($id);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resetAll(): void
+    {
+        foreach ($this->getAllProjectors() as $projector) {
+            if ($projector instanceof ReplayableProjector) {
+                $projector->reset();
+            }
+        }
+    }
+
+    /**
+     * @param Projector[] $projectors
+     */
+    private function doPlay(iterable $projectors, ?\DateTimeInterface $from, bool $continueOnError): void
+    {
+        $states = $this->mapProjectors($projectors, $continueOnError);
+
+        if ($date = $this->findLowestDateFromProjectorList($states, $from)) {
+            $stream = $this->eventStore->query()->fromDate($date)->execute();
+        } else {
+            $stream = $this->eventStore->query()->execute();
+        }
+
+        $streamSize = $stream->count();
+        $currentIndex = 0;
+
+        $this->dispatch(WorkerEvent::begin($streamSize));
+
+        if ($streamSize <= 0) {
+            $this->dispatch(WorkerEvent::end($streamSize));
+
+            return;
+        }
+
+        foreach ($stream as $event) {
+            \assert($event instanceof Event);
+
+            $this->dispatch(WorkerEvent::next($streamSize, ++$currentIndex));
+
+            $atLeastOne = false;
+
+            foreach ($states as $id => $projector) {
+                \assert($projector instanceof ProjectorState);
+
+                try {
+                    if ($projector->stopped) {
+                        continue;
+                    }
+
+                    if ($projector->position < $event->getPosition()) {
+                        $projector->instance->onEvent($event);
+                        $projector->lastEvent = $event;
+                    }
+
+                    $atLeastOne = true;
+
+                } catch (\Throwable $e) {
+                    $projector->stopped = true;
+
+                    $state = $this->stateStore->exception($id, $event, $e, true);
+                    $this->dispatch(WorkerEvent::error($streamSize, $currentIndex, $state));
+                }
+            }
+
+            if (!$atLeastOne) {
+                $this->dispatch(WorkerEvent::broken($streamSize, $currentIndex));
+
+                break;
+            }
+        }
+
+        // Finally update all projectors states.
+        foreach ($states as $id => $projector) {
+            \assert($projector instanceof ProjectorState);
+
+            if ($projector->lastEvent) {
+                $this->stateStore->update($id, $projector->lastEvent, true);
+            }
+        }
+
+        $this->dispatch(WorkerEvent::end($streamSize, $currentIndex));
+    }
+
+    /**
+     * @param array<string, ProjectorState> $projectors
+     *
+     * @return null|\DateTimeInterface
+     *   Returning null means projectors with no date exist.
+     */
+    private function findLowestDateFromProjectorList(array $projectors, ?\DateTimeInterface $minDate): ?\DateTimeInterface
+    {
+        foreach ($projectors as $projector) {
+            \assert($projector instanceof ProjectorState);
+
+            if ($projector->position < 1) {
+                return null;
+            }
+
+            $projectorDate = $projector->state->getLatestEventDate();
+
+            if (!$minDate) {
+                $minDate = $projectorDate;
+            } else if ($projectorDate < $minDate) {
+                $minDate = $projectorDate;
+            }
+        }
+
+        return $minDate;
+    }
+
+    /**
+     * Dispatch event if listeners are attached.
+     */
+    private function dispatch(WorkerEvent $event): void
+    {
+        if ($this->eventDispatcher) {
+            $this->eventDispatcher->dispatch($event, $event->getEventName());
+        }
+    }
+
+    /**
+     * @param Projector[] $projectors
+     *
+     * @return array<string, ProjectorState>
+     */
+    private function mapProjectors(iterable $projectors, bool $continueOnError)
+    {
+        $ret = [];
+
+        foreach ($projectors as $projector) {
+            \assert($projector instanceof Projector);
+
+            $id = $projector->getIdentifier();
+
+            try {
+                $state = $this->stateStore->lock($id);
+
+                if ($continueOnError || !$state->isError()) {
+                    $ret[$id] = new ProjectorState($projector, $state);
+                }
+            } catch (ProjectorLockedError $e) {
+                // Do nothing here.
+                // @todo Instrumentation: log that.
+            }
+        }
+
+        if (empty($ret)) {
+            throw new MissingProjectorError("All projectors are in error or locked, cannot continue."); 
+        }
+
+        return $ret;
+    }
+
+    /**
+     * @return Projector[]
+     */
+    private function getAllProjectors(): iterable
+    {
+        $ret = $this->projectorRegistry->getAll();
+
+        if (empty($ret)) {
+            throw new MissingProjectorError("There is no projectors, cannot continue.");
+        }
+
+        return $ret;
+    }
+
+    private function getProjector(string $id): Projector
+    {
+        return $this->projectorRegistry->find($id);
+    }
+}
+
+/**
+ * @internal
+ */
+final class ProjectorState
+{
+    public Projector $instance;
+    public State $state;
+    public int $position;
+    public ?Event $lastEvent = null;
+    public bool $stopped = false;
+
+    public function __construct(Projector $projector, ?State $state)
+    {
+        $this->instance = $projector;
+        $this->state = $state ?? State::empty($projector->getIdentifier());
+        $this->position = $this->state->getLatestEventPosition();
+    }
+}

--- a/src/Domain/Projector/Worker/DefaultWorker.php
+++ b/src/Domain/Projector/Worker/DefaultWorker.php
@@ -20,6 +20,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * Default (and propably only) implementation.
  *
  * Interface exists for the need of decorating the worker.
+ *
+ * @todo Instrument using psr/log.
  */
 final class DefaultWorker implements Worker
 {

--- a/src/Domain/Projector/Worker/MissingProjectorError.php
+++ b/src/Domain/Projector/Worker/MissingProjectorError.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\Worker;
+
+use Goat\Domain\Projector\ProjectorError;
+
+class MissingProjectorError extends \InvalidArgumentException implements ProjectorError
+{
+}

--- a/src/Domain/Projector/Worker/Worker.php
+++ b/src/Domain/Projector/Worker/Worker.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\Worker;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Projector player.
+ */
+interface Worker
+{
+    /**
+     * Get internal event dispatcher.
+     */
+    public function getEventDispatcher(): EventDispatcherInterface;
+
+    /**
+     * Play event stream for a single projector.
+     */
+    public function play(string $id, bool $reset = false, bool $continueOnError = true): void;
+
+    /**
+     * Play event stream for a single projector from date.
+     */
+    public function playFrom(string $id, \DateTimeInterface $date, bool $continueOnError = true): void;
+
+    /**
+     * Play event stream for all projectors.
+     */
+    public function playAll(bool $continueOnError = true): void;
+
+    /**
+     * Play event stream for all projectors from date.
+     */
+    public function playAllFrom(\DateTimeInterface $date, bool $continueOnError = true): void;
+
+    /**
+     * Reset all data of a single projector.
+     */
+    public function reset(string $id): void;
+
+    /**
+     * Rest all data for all projectors.
+     *
+     * Warning: you should probably never call this.
+     */
+    public function resetAll(): void;
+}

--- a/src/Domain/Projector/Worker/WorkerEvent.php
+++ b/src/Domain/Projector/Worker/WorkerEvent.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Projector\Worker;
+
+use Goat\Domain\Projector\State\State;
+
+/**
+ * Exists for updating UI.
+ */
+final class WorkerEvent
+{
+    /** Begin play procedure */
+    const BEGIN = 'projector:worker:begin';
+
+    /** Move to next event */
+    const NEXT = 'projector:worker:next';
+
+    /** A projector raised an error */
+    const ERROR = 'projector:worker:error';
+
+    /** End play procedure */
+    const END = 'projector:worker:end';
+
+    /** Premature end due to error in all projectors */
+    const BROKEN = 'projector:worker:broken';
+
+    private string $eventName;
+    private int $streamSize;
+    private int $currentPosition = 0;
+    private ?State $state = null;
+
+    public static function begin(int $streamSize): self
+    {
+        return new self(self::BEGIN, $streamSize);
+    }
+
+    public static function end(int $streamSize, int $currentPosition = null): self
+    {
+        return new self(self::END, $streamSize, $currentPosition ?? $streamSize);
+    }
+
+    public static function broken(int $streamSize, int $currentPosition = null): self
+    {
+        return new self(self::BROKEN, $streamSize, $currentPosition ?? $streamSize);
+    }
+
+    public static function error(int $streamSize, int $currentPosition, State $state): self
+    {
+        return new self(self::ERROR, $streamSize, $currentPosition, $state);
+    }
+
+    public static function next(int $streamSize, int $currentPosition): self
+    {
+        return new self(self::NEXT, $streamSize, $currentPosition);
+    }
+
+    private function __construct(
+        string $eventName,
+        int $streamSize,
+        int $currentPosition = 0,
+        ?State $state = null
+    ) {
+        $this->eventName = $eventName;
+        $this->streamSize = $streamSize;
+        $this->currentPosition = $currentPosition;
+        $this->state = $state;
+    }
+
+    public function getEventName(): string
+    {
+        return $this->eventName;
+    }
+
+    public function getStreamSize(): int
+    {
+        return $this->streamSize;
+    }
+
+    public function getCurrentPosition(): int
+    {
+        return $this->currentPosition;
+    }
+
+    public function getState(): ?State
+    {
+        return $this->state;
+    }
+}

--- a/tests/Domain/Event/MockEventStore.php
+++ b/tests/Domain/Event/MockEventStore.php
@@ -7,6 +7,7 @@ namespace Goat\Domain\Tests\Event;
 use Goat\Domain\EventStore\AbstractEventStore;
 use Goat\Domain\EventStore\Event;
 use Goat\Domain\EventStore\EventQuery;
+use Ramsey\Uuid\UuidInterface;
 
 class MockEventStore extends AbstractEventStore
 {
@@ -79,6 +80,16 @@ class MockEventStore extends AbstractEventStore
      * {@inheritdoc}
      */
     public function count(EventQuery $query): ?int
+    {
+        throw new \BadMethodCallException();
+    }
+
+    public function findByPosition(int $position): Event
+    {
+        throw new \BadMethodCallException();
+    }
+
+    public function findByRevision(UuidInterface $aggregateId, int $revision): Event
     {
         throw new \BadMethodCallException();
     }

--- a/tests/Domain/Projector/Runtime/DefaultRuntimeTest.php
+++ b/tests/Domain/Projector/Runtime/DefaultRuntimeTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Tests\Projector\Runtime;
+
+use Goat\Domain\EventStore\Event;
+use Goat\Domain\Projector\ProjectorRegistry;
+use Goat\Domain\Projector\Projector\BrokenProjector;
+use Goat\Domain\Projector\Projector\CallbackProjector;
+use Goat\Domain\Projector\Runtime\DefaultRuntimePlayer;
+use Goat\Domain\Projector\State\ArrayStateStore;
+use PHPUnit\Framework\TestCase;
+
+class DefaultRuntimeTest extends TestCase
+{
+    public function testEmptyPlayDoesNothing(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([]);
+
+        $player = new DefaultRuntimePlayer(
+            $registry,
+            new ArrayStateStore()
+        );
+
+        self::expectNotToPerformAssertions();
+        $player->dispatch($this->createEventAt(new \DateTimeImmutable(), 3));
+    }
+
+    public function testErrorDoesNotBlockOthers(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([
+            $fooProjector = new CallbackProjector('foo', static function () {
+                throw new \DomainException("I shall not fail.");
+            }),
+            $barProjector = new BrokenProjector('bar'),
+        ]);
+
+        $stateStore = new ArrayStateStore();
+
+        $player = new DefaultRuntimePlayer(
+            $registry,
+            $stateStore
+        );
+
+        $player->dispatch($this->createEventAt(new \DateTimeImmutable(), 4));
+
+        self::assertSame(1, $fooProjector->getOnEventCallCount());
+        self::assertSame(1, $barProjector->getOnEventCallCount());
+
+        $fooState = $stateStore->latest('foo');
+        self::assertTrue($fooState->isError());
+        self::assertSame(4, $fooState->getLatestEventPosition());
+
+        $barState = $stateStore->latest('bar');
+        self::assertFalse($barState->isError());
+        self::assertSame(4, $barState->getLatestEventPosition());
+    }
+
+    public function alreadyPlayedEventsDoesNotReplay(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([
+            $fooProjector = new BrokenProjector('foo'),
+            $barProjector = new BrokenProjector('bar'),
+        ]);
+
+        $stateStore = new ArrayStateStore();
+        $stateStore->update('bar', $this->createEventAt(new \DateTimeImmutable(), 7));
+
+        $player = new DefaultRuntimePlayer(
+            $registry,
+            $stateStore
+        );
+
+        $player->dispatch($this->createEventAt(new \DateTimeImmutable(), 4));
+
+        self::assertSame(1, $fooProjector->getOnEventCallCount());
+        self::assertSame(0, $barProjector->getOnEventCallCount());
+
+        $fooState = $stateStore->latest('foo');
+        self::assertFalse($fooState->isError());
+        self::assertSame(4, $fooState->getLatestEventPosition());
+
+        $barState = $stateStore->latest('bar');
+        self::assertFalse($barState->isError());
+        self::assertSame(7, $barState->getLatestEventPosition());
+    }
+
+    private function createEventAt($message, int $position, ?\DateTimeInterface $validAt = null): Event
+    {
+        $event = Event::create(new \DateTimeImmutable());
+
+        $func = \Closure::bind(
+            static function (Event $event) use ($position, $validAt) {
+                $event->position = $position;
+                $event->validAt = $validAt ?? new \DateTimeImmutable();
+            },
+            null,
+            Event::class
+        );
+
+        $func($event);
+
+        return $event;
+    }
+}

--- a/tests/Domain/Projector/State/ArrayStateStoreTest.php
+++ b/tests/Domain/Projector/State/ArrayStateStoreTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Tests\Projector\State;
+
+use Goat\Domain\Projector\State\ArrayStateStore;
+use Goat\Domain\Projector\State\StateStore;
+use PHPUnit\Framework\TestCase;
+
+class ArrayStateStoreTest extends TestCase
+{
+    use StateStoreTestTrait;
+
+    /**
+     * Create state store.
+     */
+    protected function createStateStore(): StateStore
+    {
+        return new ArrayStateStore();
+    }
+
+    public function testLockUpserts(): void
+    {
+        $this->doTestLockUpserts($this->createStateStore());
+    }
+
+    public function testLockWhenExists(): void
+    {
+        $this->doTestLockWhenExists($this->createStateStore());
+    }
+
+    public function testUnlockUpserts(): void
+    {
+        $this->doTestUnlockUpserts($this->createStateStore());
+    }
+
+    public function testUnlockWhenExists(): void
+    {
+        $this->doTestUnlockWhenExists($this->createStateStore());
+    }
+
+    public function testUpdateUpserts(): void
+    {
+        $this->doTestUpdateUpserts($this->createStateStore());
+    }
+
+    public function testUpdateWhenExists(): void
+    {
+        $this->doTestUpdateWhenExists($this->createStateStore());
+    }
+
+    public function testUpdateResetLocking(): void
+    {
+        $this->doTestUpdateResetLocking($this->createStateStore());
+    }
+
+    public function testUpdateResetError(): void
+    {
+        $this->doTestUpdateResetError($this->createStateStore());
+    }
+
+    public function testErrorUpserts(): void
+    {
+        $this->doTestErrorUpserts($this->createStateStore());
+    }
+
+    public function testErrorWhenExists(): void
+    {
+        $this->doTestErrorWhenExists($this->createStateStore());
+    }
+
+    public function testErrorResetLocking(): void
+    {
+        $this->doTestErrorResetLocking($this->createStateStore());
+    }
+
+    public function testErrorWithoutUnlock(): void
+    {
+        $this->doTestErrorWithoutUnlock($this->createStateStore());
+    }
+
+    public function testExceptionUpserts(): void
+    {
+        $this->doTestExceptionUpserts($this->createStateStore());
+    }
+
+    public function testExceptionWhenExists(): void
+    {
+        $this->doTestExceptionWhenExists($this->createStateStore());
+    }
+
+    public function testExceptionResetLocking(): void
+    {
+        $this->doTestExceptionResetLocking($this->createStateStore());
+    }
+
+    public function testExceptionWithoutUnlock(): void
+    {
+        $this->doTestExceptionWithoutUnlock($this->createStateStore());
+    }
+}

--- a/tests/Domain/Projector/State/GoatStateStoreTest.php
+++ b/tests/Domain/Projector/State/GoatStateStoreTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Tests\Projector\State;
+
+use Goat\Domain\Projector\State\GoatStateStore;
+use Goat\Domain\Projector\State\StateStore;
+use Goat\Runner\Runner;
+use Goat\Runner\Testing\DatabaseAwareQueryTest;
+use Goat\Runner\Testing\TestDriverFactory;
+
+final class GoatStateStoreTest extends DatabaseAwareQueryTest
+{
+    use StateStoreTestTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getSupportedDrivers(): ?array
+    {
+        return ['pgsql'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createTestSchema(Runner $runner)
+    {
+        $runner->execute(
+            <<<SQL
+            CREATE TABLE IF NOT EXISTS "projector_state" (
+                "id" varchar(500) NOT NULL,
+                "created_at" timestamp NOT NULL DEFAULT current_timestamp,
+                "updated_at" timestamp NOT NULL DEFAULT current_timestamp,
+                "last_position" bigint NOT NULL DEFAULT 0,
+                "last_valid_at" timestamp NOT NULL DEFAULT current_timestamp,
+                "is_locked" bool NOT NULL DEFAULT false,
+                "is_error" bool NOT NULL DEFAULT false,
+                "error_code" bigint NOT NULL DEFAULT 0,
+                "error_message" text DEFAULT null,
+                "error_trace" text DEFAULT null,
+                PRIMARY KEY("id")
+            );
+            SQL
+        );
+
+        $runner->execute('DELETE FROM "projector_state";');
+    }
+
+    /**
+     * Create your own event store
+     *
+     * Override this for your own event store.
+     */
+    protected function createStateStore(Runner $runner, string $schema): StateStore
+    {
+        $this->createTestSchema($runner);
+
+        return new GoatStateStore($runner, $schema);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testLockUpserts(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestLockUpserts($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testLockWhenExists(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestLockWhenExists($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testUnlockUpserts(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestUnlockUpserts($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testUnlockWhenExists(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestUnlockWhenExists($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testUpdateUpserts(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestUpdateUpserts($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testUpdateWhenExists(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestUpdateWhenExists($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testUpdateResetLocking(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestUpdateResetLocking($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testUpdateResetError(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestUpdateResetError($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testErrorUpserts(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestErrorUpserts($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testErrorWhenExists(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestErrorWhenExists($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testErrorResetLocking(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestErrorResetLocking($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testErrorWithoutUnlock(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestErrorWithoutUnlock($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testExceptionUpserts(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestExceptionUpserts($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testExceptionWhenExists(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestExceptionWhenExists($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testExceptionResetLocking(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestExceptionResetLocking($stateStore);
+    }
+
+    /**
+     * @dataProvider runnerDataProvider
+     */
+    public function testExceptionWithoutUnlock(TestDriverFactory $factory): void
+    {
+        $runner = $factory->getRunner();
+
+        $stateStore = $this->createStateStore($runner, $factory->getSchema());
+
+        $this->doTestExceptionWithoutUnlock($stateStore);
+    }
+}
+

--- a/tests/Domain/Projector/State/StateStoreTestTrait.php
+++ b/tests/Domain/Projector/State/StateStoreTestTrait.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Tests\Projector\State;
+
+use Goat\Domain\EventStore\Event;
+use Goat\Domain\Projector\State\StateStore;
+use Goat\Domain\Projector\State\ProjectorLockedError;
+
+trait StateStoreTestTrait
+{
+    protected function doTestLockUpserts(StateStore $stateStore): void
+    {
+        self::assertNull($stateStore->latest('foo'));
+
+        $ret = $stateStore->lock('foo');
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertTrue($ret->isLocked());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertTrue($load->isLocked());
+    }
+
+    protected function doTestLockWhenExists(StateStore $stateStore): void
+    {
+        $prev = $stateStore->update('foo', $this->createEventAt(new \DateTimeImmutable()));
+        self::assertSame('foo', $prev->getProjectorId());
+        self::assertFalse($prev->isLocked());
+
+        $ret = $stateStore->lock('foo');
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertTrue($ret->isLocked());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertTrue($load->isLocked());
+    }
+
+    protected function doTestLockWhenLockedRaiseError(StateStore $stateStore): void
+    {
+        self::assertNull($stateStore->latest('foo'));
+
+        $ret = $stateStore->lock('foo');
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertTrue($ret->isLocked());
+
+        self::expectException(ProjectorLockedError::class);
+        $stateStore->lock('foo');
+    }
+
+    protected function doTestUnlockUpserts(StateStore $stateStore): void
+    {
+        self::assertNull($stateStore->latest('foo'));
+
+        $ret = $stateStore->unlock('foo');
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertFalse($ret->isLocked());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertFalse($load->isLocked());
+    }
+
+    protected function doTestUnlockWhenExists(StateStore $stateStore): void
+    {
+        $stateStore->update('foo', $this->createEventAt(new \DateTimeImmutable(), 2));
+        $prev = $stateStore->lock('foo');
+        self::assertSame('foo', $prev->getProjectorId());
+        self::assertTrue($prev->isLocked());
+
+        $ret = $stateStore->unlock('foo', $this->createEventAt(new \DateTimeImmutable(), 17));
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertFalse($ret->isLocked());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertFalse($ret->isLocked());
+    }
+
+    protected function doTestUpdateUpserts(StateStore $stateStore): void
+    {
+        self::assertNull($stateStore->latest('foo'));
+
+        $ret = $stateStore->update('foo', $this->createEventAt(new \DateTimeImmutable(), 32));
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertSame(32, $ret->getLatestEventPosition());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertSame(32, $load->getLatestEventPosition());
+    }
+
+    protected function doTestUpdateWhenExists(StateStore $stateStore): void
+    {
+        $stateStore->update('foo', $this->createEventAt(new \DateTimeImmutable(), 2));
+        $prev = $stateStore->lock('foo');
+        self::assertSame('foo', $prev->getProjectorId());
+        self::assertSame(2, $prev->getLatestEventPosition());
+
+        $ret = $stateStore->update('foo', $this->createEventAt(new \DateTimeImmutable(), 17));
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertSame(17, $ret->getLatestEventPosition());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertSame(17, $load->getLatestEventPosition());
+    }
+
+    protected function doTestUpdateResetLocking(StateStore $stateStore): void
+    {
+        $stateStore->update('foo', $this->createEventAt(new \DateTimeImmutable(), 2));
+        $prev = $stateStore->lock('foo');
+        self::assertSame('foo', $prev->getProjectorId());
+        self::assertSame(2, $prev->getLatestEventPosition());
+        self::assertTrue($prev->isLocked());
+
+        $ret = $stateStore->update('foo', $this->createEventAt(new \DateTimeImmutable(), 17), false);
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertSame(17, $ret->getLatestEventPosition());
+        self::assertTrue($ret->isLocked());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertSame(17, $load->getLatestEventPosition());
+        self::assertTrue($load->isLocked());
+
+        $ret = $stateStore->update('foo', $this->createEventAt(new \DateTimeImmutable(), 17));
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertSame(17, $ret->getLatestEventPosition());
+        self::assertFalse($ret->isLocked());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertSame(17, $load->getLatestEventPosition());
+        self::assertFalse($load->isLocked());
+    }
+
+    protected function doTestUpdateResetError(StateStore $stateStore): void
+    {
+        $prev = $stateStore->error('foo', $this->createEventAt(new \DateTimeImmutable(), 29), 'This is terrible.', 27);
+        self::assertSame('foo', $prev->getProjectorId());
+        self::assertTrue($prev->isError());
+        self::assertSame(27, $prev->getErrorCode());
+        self::assertSame('This is terrible.', $prev->getErrorMessage());
+
+        $ret = $stateStore->update('foo', $this->createEventAt(new \DateTimeImmutable(), 30), false);
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertFalse($ret->isError());
+        self::assertSame(0, $ret->getErrorCode());
+        self::assertNull($ret->getErrorMessage());
+        self::assertNull($ret->getErrorTrace());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertFalse($load->isError());
+        self::assertSame(0, $load->getErrorCode());
+        self::assertNull($load->getErrorMessage());
+        self::assertNull($load->getErrorTrace());
+    }
+
+    protected function doTestErrorUpserts(StateStore $stateStore): void
+    {
+        self::assertNull($stateStore->latest('foo'));
+
+        $ret = $stateStore->error('foo', $this->createEventAt(new \DateTimeImmutable(), 29), 'This is terrible.', 27);
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertTrue($ret->isError());
+        self::assertSame(29, $ret->getLatestEventPosition());
+        self::assertSame(27, $ret->getErrorCode());
+        self::assertSame('This is terrible.', $ret->getErrorMessage());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertTrue($load->isError());
+        self::assertSame(29, $load->getLatestEventPosition());
+        self::assertSame(27, $load->getErrorCode());
+        self::assertSame('This is terrible.', $load->getErrorMessage());
+    }
+
+    protected function doTestErrorWhenExists(StateStore $stateStore): void
+    {
+        self::markTestIncomplete("Implement me");
+    }
+
+    protected function doTestErrorResetLocking(StateStore $stateStore): void
+    {
+        self::markTestIncomplete("Implement me");
+    }
+
+    protected function doTestErrorWithoutUnlock(StateStore $stateStore): void
+    {
+        self::markTestIncomplete("Implement me");
+    }
+
+    protected function doTestExceptionUpserts(StateStore $stateStore): void
+    {
+        self::assertNull($stateStore->latest('foo'));
+
+        $ret = $stateStore->exception('foo', $this->createEventAt(new \DateTimeImmutable(), 29), new \Exception("Foo Bar !", 7));
+        self::assertSame('foo', $ret->getProjectorId());
+        self::assertTrue($ret->isError());
+        self::assertSame(29, $ret->getLatestEventPosition());
+        self::assertSame(7, $ret->getErrorCode());
+        self::assertSame('Foo Bar !', $ret->getErrorMessage());
+
+        $load = $stateStore->latest('foo');
+        self::assertSame('foo', $load->getProjectorId());
+        self::assertTrue($load->isError());
+        self::assertSame(29, $load->getLatestEventPosition());
+        self::assertSame(7, $load->getErrorCode());
+        self::assertSame('Foo Bar !', $load->getErrorMessage());
+    }
+
+    protected function doTestExceptionWhenExists(StateStore $stateStore): void
+    {
+        self::markTestIncomplete("Implement me");
+    }
+
+    protected function doTestExceptionResetLocking(StateStore $stateStore): void
+    {
+        self::markTestIncomplete("Implement me");
+    }
+
+    protected function doTestExceptionWithoutUnlock(StateStore $stateStore): void
+    {
+        self::markTestIncomplete("Implement me");
+    }
+
+    private function createEventAt($message, int $position = 1, ?\DateTimeInterface $validAt = null): Event
+    {
+        $event = Event::create(new \DateTimeImmutable());
+
+        $func = \Closure::bind(
+            static function (Event $event) use ($position, $validAt) {
+                $event->position = $position;
+                $event->validAt = $validAt ?? new \DateTimeImmutable();
+            },
+            null,
+            Event::class
+        );
+
+        $func($event);
+
+        return $event;
+    }
+}

--- a/tests/Domain/Projector/Worker/DefaultWorkerTest.php
+++ b/tests/Domain/Projector/Worker/DefaultWorkerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Goat\Domain\Tests\Projector;
+namespace Goat\Domain\Tests\Projector\Worker;
 
 use Goat\Domain\EventStore\AbstractEventQuery;
 use Goat\Domain\EventStore\AbstractEventStore;

--- a/tests/Domain/Projector/Worker/DefaultWorkerTest.php
+++ b/tests/Domain/Projector/Worker/DefaultWorkerTest.php
@@ -1,0 +1,418 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goat\Domain\Tests\Projector;
+
+use Goat\Domain\EventStore\AbstractEventQuery;
+use Goat\Domain\EventStore\AbstractEventStore;
+use Goat\Domain\EventStore\Event;
+use Goat\Domain\EventStore\EventQuery;
+use Goat\Domain\EventStore\EventStore;
+use Goat\Domain\EventStore\EventStream;
+use Goat\Domain\EventStore\Testing\DummyArrayEventStream;
+use Goat\Domain\Projector\ProjectorDoesNotExistError;
+use Goat\Domain\Projector\ProjectorRegistry;
+use Goat\Domain\Projector\Projector\BrokenProjector;
+use Goat\Domain\Projector\Projector\CallbackProjector;
+use Goat\Domain\Projector\State\ArrayStateStore;
+use Goat\Domain\Projector\Worker\DefaultWorker;
+use Goat\Domain\Projector\Worker\MissingProjectorError;
+use Goat\Domain\Projector\Worker\WorkerEvent;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\UuidInterface;
+
+class DefaultWorkerTest extends TestCase
+{
+    public function testEmptyRegistryRaiseError(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([]);
+
+        $worker = new DefaultWorker(
+            $registry,
+            $this->createNullEventStore(),
+            new ArrayStateStore()
+        );
+
+        self::expectException(MissingProjectorError::class);
+        $worker->playAll();
+    }
+
+    public function testNonExistingProjectorRaiseError(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([
+            new BrokenProjector('foo'),
+        ]);
+
+        $worker = new DefaultWorker(
+            $registry,
+            $this->createNullEventStore(),
+            new ArrayStateStore()
+        );
+
+        self::expectException(ProjectorDoesNotExistError::class);
+        $worker->play('bar');
+    }
+
+    public function testEmptyEventStreamRaiseStartAndEndEvent(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([
+            new BrokenProjector('foo'),
+        ]);
+
+        $worker = new DefaultWorker(
+            $registry,
+            $this->createNullEventStore(),
+            new ArrayStateStore()
+        );
+
+        $beginCount = 0;
+        $endCount = 0;
+
+        $dispatcher = $worker->getEventDispatcher();
+        $dispatcher->addListener(WorkerEvent::BEGIN, static function () use (&$beginCount) {
+            ++$beginCount;
+        });
+        $dispatcher->addListener(WorkerEvent::END, static function () use (&$endCount) {
+            ++$endCount;
+        });
+
+        $dispatcher->addListener(WorkerEvent::NEXT, static function () {
+            throw new \BadMethodCallException();
+        });
+        $dispatcher->addListener(WorkerEvent::ERROR, static function () {
+            throw new \BadMethodCallException();
+        });
+        $dispatcher->addListener(WorkerEvent::BROKEN, static function () {
+            throw new \BadMethodCallException();
+        });
+
+        $worker->playAll();
+
+        self::assertSame(1, $beginCount);
+        self::assertSame(1, $endCount);
+    }
+
+    public function testLockedProjectorDoesNotPlay(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([
+            $fooProjector = new BrokenProjector('foo'),
+            $barProjector = new BrokenProjector('bar'),
+        ]);
+
+        $stateStore = new ArrayStateStore();
+
+        $worker = new DefaultWorker(
+            $registry,
+            $this->createNullEventStore([
+                $this->createEventAt(new \DateTimeImmutable(), 1),
+                $this->createEventAt(new \DateTimeImmutable(), 2),
+                $this->createEventAt(new \DateTimeImmutable(), 3),
+            ]),
+            $stateStore
+        );
+
+        $stateStore->lock('bar'); 
+
+        $worker->playAll();
+
+        self::assertSame(3, $fooProjector->getOnEventCallCount());
+        self::assertSame(0, $barProjector->getOnEventCallCount());
+
+        $stateFoo = $stateStore->latest('foo');
+        self::assertSame(3, $stateFoo->getLatestEventPosition());
+        self::assertFalse($stateFoo->isLocked());
+
+        $stateBar = $stateStore->latest('bar');
+        self::assertsame(0, $stateBar->getLatestEventPosition());
+        self::assertTrue($stateBar->isLocked());
+    }
+
+    public function testErroneousProjectorDoesNotPlay(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([
+            $fooProjector = new BrokenProjector('foo'),
+            $barProjector = new BrokenProjector('bar'),
+        ]);
+
+        $stateStore = new ArrayStateStore();
+
+        $worker = new DefaultWorker(
+            $registry,
+            $this->createNullEventStore([
+                $this->createEventAt(new \DateTimeImmutable(), 1),
+                $this->createEventAt(new \DateTimeImmutable(), 2),
+                $this->createEventAt(new \DateTimeImmutable(), 3),
+            ]),
+            $stateStore
+        );
+
+        $stateStore->error(
+            'bar',
+            $this->createEventAt(new \DateTimeImmutable(), 1),
+            'Foo error'
+        );
+
+        $worker->playAll();
+
+        self::assertSame(3, $fooProjector->getOnEventCallCount());
+        self::assertSame(0, $barProjector->getOnEventCallCount());
+
+        $stateFoo = $stateStore->latest('foo');
+        self::assertSame(3, $stateFoo->getLatestEventPosition());
+        self::assertFalse($stateFoo->isLocked());
+
+        $stateBar = $stateStore->latest('bar');
+        self::assertsame(1, $stateBar->getLatestEventPosition());
+        self::assertTrue($stateBar->isError());
+    }
+
+    public function testErroneousProjectorDoesPlayWhenContinueOnError(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([
+            $fooProjector = new BrokenProjector('foo'),
+            $barProjector = new BrokenProjector('bar'),
+        ]);
+
+        $stateStore = new ArrayStateStore();
+
+        $worker = new DefaultWorker(
+            $registry,
+            $this->createNullEventStore([
+                $this->createEventAt(new \DateTimeImmutable(), 1),
+                $this->createEventAt(new \DateTimeImmutable(), 2),
+                $this->createEventAt(new \DateTimeImmutable(), 3),
+            ]),
+            $stateStore
+        );
+
+        $stateStore->error(
+            'bar',
+            $this->createEventAt(new \DateTimeImmutable(), 1),
+            'Foo error'
+        );
+
+        $worker->playAll(true);
+
+        self::assertSame(3, $fooProjector->getOnEventCallCount());
+        self::assertSame(2, $barProjector->getOnEventCallCount());
+
+        $stateFoo = $stateStore->latest('foo');
+        self::assertSame(3, $stateFoo->getLatestEventPosition());
+        self::assertFalse($stateFoo->isLocked());
+
+        $stateBar = $stateStore->latest('bar');
+        self::assertsame(3, $stateBar->getLatestEventPosition());
+        self::assertFalse($stateBar->isError());
+    }
+
+    public function testWhenErrorRaisedProjectorIsStopped(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([
+            $fooProjector = new BrokenProjector('foo'),
+            $barProjector = new CallbackProjector('bar', static function (Event $event): void {
+                throw new \DomainException("Something really bad happened.");
+            }),
+        ]);
+
+        $stateStore = new ArrayStateStore();
+
+        $worker = new DefaultWorker(
+            $registry,
+            $this->createNullEventStore([
+                $this->createEventAt(new \DateTimeImmutable(), 1),
+                $this->createEventAt(new \DateTimeImmutable(), 2),
+                $this->createEventAt(new \DateTimeImmutable(), 3),
+            ]),
+            $stateStore
+        );
+
+        $beginCount = 0;
+        $endCount = 0;
+
+        $dispatcher = $worker->getEventDispatcher();
+        $dispatcher->addListener(WorkerEvent::BEGIN, static function () use (&$beginCount) {
+            ++$beginCount;
+        });
+        $dispatcher->addListener(WorkerEvent::END, static function () use (&$endCount) {
+            ++$endCount;
+        });
+
+        $worker->playAll();
+
+        self::assertSame(3, $fooProjector->getOnEventCallCount());
+        self::assertSame(1, $barProjector->getOnEventCallCount());
+
+        self::assertSame(1, $beginCount);
+        self::assertSame(1, $endCount);
+
+        $stateFoo = $stateStore->latest('foo');
+        self::assertFalse($stateFoo->isError());
+        self::assertFalse($stateFoo->isLocked());
+        self::assertSame(3, $stateFoo->getLatestEventPosition());
+        self::assertNull($stateFoo->getErrorMessage());
+
+        $stateBar = $stateStore->latest('bar');
+        self::assertTrue($stateBar->isError());
+        self::assertFalse($stateBar->isLocked());
+        self::assertSame(1, $stateBar->getLatestEventPosition());
+        self::assertSame('Something really bad happened.', $stateBar->getErrorMessage());
+    }
+
+    public function testAlreadyAdvancedProjectorsAreNotPlayedAgain(): void
+    {
+        $registry = new ProjectorRegistry();
+        $registry->setProjectors([
+            $fooProjector = new BrokenProjector('foo'),
+            $barProjector = new BrokenProjector('bar'),
+        ]);
+
+        $stateStore = new ArrayStateStore();
+
+        $worker = new DefaultWorker(
+            $registry,
+            $this->createNullEventStore([
+                $this->createEventAt(new \DateTimeImmutable(), 1),
+                $this->createEventAt(new \DateTimeImmutable(), 2),
+                $this->createEventAt(new \DateTimeImmutable(), 3),
+            ]),
+            $stateStore
+        );
+
+        $stateStore->update(
+            'foo',
+            $this->createEventAt(new \DateTimeImmutable(), 2)
+        );
+
+        $stateStore->update(
+            'bar',
+            $this->createEventAt(new \DateTimeImmutable(), 1)
+        );
+
+        $worker->playAll(true);
+
+        self::assertSame(1, $fooProjector->getOnEventCallCount());
+        self::assertSame(2, $barProjector->getOnEventCallCount());
+
+        $stateFoo = $stateStore->latest('foo');
+        self::assertSame(3, $stateFoo->getLatestEventPosition());
+
+        $stateBar = $stateStore->latest('bar');
+        self::assertsame(3, $stateBar->getLatestEventPosition());
+    }
+
+    public function testDateMagic(): void
+    {
+        self::markTestIncomplete("Implement me.");
+    }
+
+    private function createEventAt($message, int $position, ?\DateTimeInterface $validAt = null): Event
+    {
+        $event = Event::create(new \DateTimeImmutable());
+
+        $func = \Closure::bind(
+            static function (Event $event) use ($position, $validAt) {
+                $event->position = $position;
+                $event->validAt = $validAt ?? new \DateTimeImmutable();
+            },
+            null,
+            Event::class
+        );
+
+        $func($event);
+
+        return $event;
+    }
+
+    private function createNullEventStore(array $events = []): EventStore
+    {
+        return new class ($events) extends AbstractEventStore
+        {
+            private array $events;
+
+            public function __construct(array $events)
+            {
+                $this->events = $events;
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function findByPosition(int $position): Event
+            {
+                throw new \Exception("Not implemented.");
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function query(): EventQuery
+            {
+                return new class ($this->events) extends AbstractEventQuery
+                {
+                    private array $events;
+
+                    public function __construct(array $events)
+                    {
+                        $this->events = $events;
+                    }
+
+                    /**
+                     * {@inheritdoc}
+                     */
+                    public function execute(): EventStream
+                    {
+                        return new DummyArrayEventStream($this->events);
+                    }
+                };
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function count(EventQuery $query): ?int
+            {
+                throw new \Exception("Not implemented.");
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function findByRevision(UuidInterface $aggregateId, int $revision): Event
+            {
+                throw new \Exception("Not implemented.");
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            protected function doMoveAt(Event $event, int $newRevision): Event
+            {
+                throw new \Exception("Not implemented.");
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            protected function doStore(Event $event): Event
+            {
+                throw new \Exception("Not implemented.");
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            protected function doUpdate(Event $event): Event
+            {
+                throw new \Exception("Not implemented.");
+            }
+        };
+    }
+}

--- a/tests/Domain/Projector/Worker/DefaultWorkerTest.php
+++ b/tests/Domain/Projector/Worker/DefaultWorkerTest.php
@@ -56,7 +56,7 @@ class DefaultWorkerTest extends TestCase
         $worker->play('bar');
     }
 
-    public function testEmptyEventStreamRaiseStartAndEndEvent(): void
+    public function testEmptyEventStreamRaiseBeginAndEndEvent(): void
     {
         $registry = new ProjectorRegistry();
         $registry->setProjectors([
@@ -234,15 +234,11 @@ class DefaultWorkerTest extends TestCase
             $stateStore
         );
 
-        $beginCount = 0;
-        $endCount = 0;
+        $errorCount = 0;
 
         $dispatcher = $worker->getEventDispatcher();
-        $dispatcher->addListener(WorkerEvent::BEGIN, static function () use (&$beginCount) {
-            ++$beginCount;
-        });
-        $dispatcher->addListener(WorkerEvent::END, static function () use (&$endCount) {
-            ++$endCount;
+        $dispatcher->addListener(WorkerEvent::ERROR, static function () use (&$errorCount) {
+            ++$errorCount;
         });
 
         $worker->playAll();
@@ -250,8 +246,7 @@ class DefaultWorkerTest extends TestCase
         self::assertSame(3, $fooProjector->getOnEventCallCount());
         self::assertSame(1, $barProjector->getOnEventCallCount());
 
-        self::assertSame(1, $beginCount);
-        self::assertSame(1, $endCount);
+        self::assertSame(1, $errorCount);
 
         $stateFoo = $stateStore->latest('foo');
         self::assertFalse($stateFoo->isError());


### PR DESCRIPTION
Implementation of https://github.com/makinacorpus/php-goat/issues/11

 - [x] add state store interface
 - [x] write array state store for unit tests
 - [x] add worker interface
 - [x] write worker
 - [x] write worker unit tests
 - [x] write state store pgsql implementation
 - [x] write array and pgsql state store unit tests, mutualise them
 - [x] convert actual play command to use worker
 - [x] add runtime player interface
 - [x] write runtime player
 - [x] write runtime player unit tests
 - ~~use runtime player as an abstract dispatcher decorator~~ See #13
 - ~~make it optional, configurable, and document it~~ See #13
 - ~~add status command to display projectors and their status~~ See #13 
 - ~~add clear command for reseting projectors errors states~~ See #13  
 - ~~add reset command for deleting projectors data~~ See #13  
 - ~~write clear and reset unit tests~~ See #13  
 - ~~document how to use projectors via a cron run~~ See #13  
